### PR TITLE
Allow Faraday to follow redirects

### DIFF
--- a/chgk_rating.gemspec
+++ b/chgk_rating.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ['README.md']
   spec.require_paths    = ['lib']
 
-  spec.add_dependency 'faraday',                       '~> 0.13'
-  spec.add_dependency 'multi_json',                    '~> 1.12'
+  spec.add_dependency 'faraday',                       '~> 1.8'
+  spec.add_dependency 'faraday_middleware',            '~> 1.2'
+  spec.add_dependency 'multi_json',                    '~> 1.15'
 
   spec.add_development_dependency 'rake',                      '~> 12.1'
   spec.add_development_dependency 'rspec',                     '~> 3.6'

--- a/lib/chgk_rating/connection.rb
+++ b/lib/chgk_rating/connection.rb
@@ -1,3 +1,5 @@
+require 'faraday_middleware'
+
 module ChgkRating
   module Connection
     BASE_URL = 'http://rating.chgk.info/api'.freeze
@@ -12,6 +14,7 @@ module ChgkRating
       }
 
       Faraday.new options do |faraday|
+        faraday.use FaradayMiddleware::FollowRedirects
         faraday.adapter Faraday.default_adapter
       end
     end

--- a/lib/chgk_rating/models/base.rb
+++ b/lib/chgk_rating/models/base.rb
@@ -1,4 +1,3 @@
-require 'pry'
 module ChgkRating
   module Models
     class Base < ChgkObject


### PR DESCRIPTION
### Summary

API is redirecting http requests to https. Faraday middleware is needed to follow these redirections.
