### PR TITLE
Switch to Faraday v2

### DIFF
--- a/chgk_rating.gemspec
+++ b/chgk_rating.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ['README.md']
   spec.require_paths    = ['lib']
 
-  spec.add_dependency 'faraday',                       '~> 1.8'
-  spec.add_dependency 'faraday_middleware',            '~> 1.2'
+  spec.add_dependency 'faraday',                       '~> 2.0'
+  spec.add_dependency 'faraday-follow_redirects',      '~> 0.3'
   spec.add_dependency 'multi_json',                    '~> 1.15'
 
   spec.add_development_dependency 'rake',                      '~> 13.0'

--- a/lib/chgk_rating/connection.rb
+++ b/lib/chgk_rating/connection.rb
@@ -1,4 +1,4 @@
-require 'faraday_middleware'
+require 'faraday/follow_redirects'
 
 module ChgkRating
   module Connection
@@ -14,7 +14,7 @@ module ChgkRating
       }
 
       Faraday.new options do |faraday|
-        faraday.use FaradayMiddleware::FollowRedirects
+        faraday.use Faraday::FollowRedirects::Middleware
         faraday.adapter Faraday.default_adapter
       end
     end


### PR DESCRIPTION
### Summary

There are still some methods in old API not implemented in new API (and vice versa). As a result both `chgk_rating` and `rating-chgk-v2` should be used in some cases. Using same version of Faraday makes it possible.