### PR TITLE
Fix boolean-to-boolean conversion issue

### DIFF
--- a/lib/chgk_rating/utils/transformations.rb
+++ b/lib/chgk_rating/utils/transformations.rb
@@ -38,7 +38,7 @@ module ChgkRating
         end
 
         def to_boolean
-          ->(d) { !d.to_i.zero? }
+          ->(d) { d.respond_to?(:to_i) ? !d.to_i.zero? : !!d }
         end
 
         def to_binary_boolean

--- a/spec/lib/chgk_rating/client_spec.rb
+++ b/spec/lib/chgk_rating/client_spec.rb
@@ -30,12 +30,24 @@ RSpec.describe ChgkRating::Client do
   end
 
   describe '#team_at_tournament' do
-    subject { test_client.team_at_tournament tournament_3506, team_52853 }
+    context 'lazy loaded objects' do
+      subject { test_client.team_at_tournament tournament_3506, team_52853 }
 
-    it { is_expected.to be_an_instance_of ChgkRating::Models::TournamentTeam }
+      it { is_expected.to be_an_instance_of ChgkRating::Models::TournamentTeam }
 
-    include_examples 'lazy loaded' do
-      let(:object) { subject }
+      include_examples 'lazy loaded' do
+        let(:object) { subject }
+      end
+    end
+
+    context 'eager loaded objects' do
+      subject { test_client.team_at_tournament test_client.tournament(3506, false), test_client.team(52_853, false) }
+
+      it { is_expected.to be_an_instance_of ChgkRating::Models::TournamentTeam }
+
+      include_examples 'lazy loaded' do
+        let(:object) { subject }
+      end
     end
   end
 

--- a/spec/lib/chgk_rating/utils/transformations_spec.rb
+++ b/spec/lib/chgk_rating/utils/transformations_spec.rb
@@ -2,8 +2,10 @@
 
 RSpec.describe ChgkRating::Utils::Transformations do
   specify '.to_boolean' do
-    expect(described_class.send(:to_boolean).call('1')).to be(true)
-    expect(described_class.send(:to_boolean).call('0')).to be(false)
+    expect(described_class.send(:to_boolean).call('1')).to be_truthy
+    expect(described_class.send(:to_boolean).call('0')).to be_falsey
+    expect(described_class.send(:to_boolean).call(true)).to be_truthy
+    expect(described_class.send(:to_boolean).call(false)).to be_falsey
   end
 
   specify '.to_binary_boolean' do


### PR DESCRIPTION
### Summary

Failing code example:
```ruby
team = ChgkRating.client.team 40348, false
result = ChgkRating.client.team_at_tournament(team, 8083)
```

Using object with loaded data as parameter for `ChgkRating.client` methods (ex. `team_at_tournament`) can cause an exception (in case object contains any boolean attribute). The same code with lazy-loaded team will work fine.
Changed to_boolean transformation method. Now it will convert to boolean any object that is not responding to to_i.